### PR TITLE
Make string_to_check be customizable

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -15,3 +15,24 @@ jobs:
         uses: ./ # run action.yml from the root of this repo
         with:
           command: disp('Action is working as expected')
+          
+      - name: Test if the string_to_check works (1/2)
+        uses: ./
+        with:
+          command: disp('SUCCESS this does not match')
+          string_to_check: 'FAILED'
+          
+      - name: Test if the string_to_check works (2/2)
+        id: should-fail
+        continue-on-error: true
+        uses: ./
+        with:
+          command: disp('FAILED this does match')
+          string_to_check: 'FAILED'
+      
+      - name: Handle success of 2nd string_to_check
+        if: steps.should-fail.outcome == 'success'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed("string_to_check 2/2 should have failed but didn't.")

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ jobs:
         uses: repos4u/octave-action@v1
         with:
           command: disp('Use any octave command here');
+          string_to_check: "FAILED" # optional, default is "Error"
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,16 @@ inputs:
     description: Octave command for executing in GH runner
     required: true
     default: disp('Supply any Octave command for executing')
+  string_to_check:
+    description: String to find in output of octave. If it matches, the action has failed
+    required: false
+    default: Error
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args: # Command to be passed to the Docker container
     - ${{ inputs.command }}
+    - ${{ inputs.string_to_check }}
 branding:
   icon: 'code'
   color: 'purple'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,7 @@ echo -e "Octave output:\n$output"
 string_to_check="$2"
 # Check if the string was found
 if echo "$output" | grep -q "$string_to_check"; then
+    echo "output matched '$string_to_check'"
     exit 1
 fi
+echo "output didn't match '$string_to_check'"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 output=$(octave --eval "$1" 2>&1)
-echo -e "Octave output:\n$output"
+echo "Octave output:\n$output"
 
 string_to_check="$2"
 # Check if the string was found

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
 
-output=$(octave --eval "$1")
-echo "Octave output:\n$output"
+output=$(octave --eval "$1" 2>&1)
+echo -e "Octave output:\n$output"
 
-string_to_check="Error"
+string_to_check="$2"
 # Check if the string was found
 if echo "$output" | grep -q "$string_to_check"; then
     exit 1


### PR DESCRIPTION
This pull request introduces a new feature to the GitHub Actions workflow by switching from `string_to_check` bein a constant (`"Error"`) to being a parameter, which allows the user to specify which string should not be found in the output. The most important changes include updates to the workflow configuration, the action's README, the `action.yml` file, and the entrypoint script.

### New Feature: `string_to_check` Parameter

* **Workflow Configuration**:
  * [`.github/workflows/test-actions.yml`](diffhunk://#diff-e3935040aa017c086385661529a7cfa1428d60d5161a727d1872411a898b1490R18-R38): Added steps to test the `string_to_check` parameter, including handling success and failure cases.

* **Documentation**:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26): Updated to include the `string_to_check` parameter in the usage example.

* **Action Configuration**:
  * [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R9-R18): Added the `string_to_check` input parameter with a description and default value. Updated the Docker arguments to include this new parameter.

* **Entrypoint Script**:
  * [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L3-R12): Modified to accept the `string_to_check` parameter and check if it is present in the Octave output, causing the action to fail if a match is found.